### PR TITLE
Ignore edits when searching for titles

### DIFF
--- a/ircbot/plugins/links.py
+++ b/ircbot/plugins/links.py
@@ -43,6 +43,9 @@ def truncate_title(title):
 def link_title_parse_hook(bot, channel, sender, message):
     if not allowed_to_process(bot, channel):
         return
+    elif message.startswith("[edit]"):
+        # Ignore edits for interpreting titles
+        return
 
     for word in message.split(" "):
         for ignore in bot.config['Links']['ignore'].split():


### PR DESCRIPTION
Frequently, people on Discord edit their messages, especially with links in them. This causes a double response from `botbot` when it need only respond once. In this case, we can just blanket ignore messages that start with `[edit]`.